### PR TITLE
Fix debug prefix in IMELoggerEntry

### DIFF
--- a/ForegroundWindowLogger/IMECoreLogger/dllmain.cpp
+++ b/ForegroundWindowLogger/IMECoreLogger/dllmain.cpp
@@ -16,7 +16,7 @@ extern "C" __declspec(dllexport) void CALLBACK IMELoggerEntry(HWND hwnd, HINSTAN
 
 	if (!getDLLPath(dllPath)) {
 		if (DEBUG)
-			DEBUGlogger(L"ExplorerMain | Fail to get DLL path");
+			DEBUGlogger(L"IMELoggerEntry | Fail to get DLL path");
 		ExitProcess(-1);
 	}
 
@@ -31,7 +31,7 @@ extern "C" __declspec(dllexport) void CALLBACK IMELoggerEntry(HWND hwnd, HINSTAN
 
 	if (!getDLLPath(dllPath)) {
 		if (DEBUG)
-			DEBUGlogger(L"ExplorerMain | Fail to get DLL path");
+			DEBUGlogger(L"IMELoggerEntry | Fail to get DLL path");
 		exit(-1);
 	}
 	if (DEBUG) {


### PR DESCRIPTION
## Summary
- update debug messages in `dllmain.cpp` to use `IMELoggerEntry` prefix

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683fcd25b524832f99be6640a8966c4f